### PR TITLE
fix: missing required exports

### DIFF
--- a/lib/flutter_openim_sdk.dart
+++ b/lib/flutter_openim_sdk.dart
@@ -35,5 +35,7 @@ export 'src/models/notification_info.dart';
 export 'src/models/search_info.dart';
 export 'src/models/user_info.dart';
 export 'src/models/input_status_changed_data.dart';
+export 'src/models/set_group_member_info.dart';
+export 'src/models/update_req.dart';
 export 'src/openim.dart';
 export 'src/utils.dart';


### PR DESCRIPTION
缺失的部分导出，会导致需要额外引用 `import "package:flutter_openim_sdk/src/models/update_req.dart";`，最终导致:

```
Import of a library in the 'lib/src' directory of another package.
Try importing a public library that exports this library, or removing the import.dartimplementation_imports
```


## 🅰 Please add the issue ID after "Fixes #"

Fixes #
