### PR TITLE
android add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.openim.flutter_openim_sdk"
     compileSdkVersion 34
 
     defaultConfig {


### PR DESCRIPTION
Fixes #

In the new version of flutter 3.24.5 and above, if the android app/build.gradle does not have a namespace, it will cause an error when build release apk.

my gradle & kotlin version 


```
// gradle-wrapper.properties
distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
```



```
// settings.gradle
plugins {
    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
    id "com.android.application" version "8.1.0" apply false
    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
}
```

